### PR TITLE
Add Terraform GitHub provider documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,4 @@ Layer 0 : manual first repo for infra
 # Source material
 https://blog.ricardof.dev/setup-self-hosted-github-action-runner-in-minutes/
 https://gist.github.com/lbssousa/bb081e35d483520928033b2797133d5e
+https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository


### PR DESCRIPTION
This pull request makes a minor update to the `README.md` file by adding a new reference link to the Terraform GitHub provider documentation. This provides additional context for managing GitHub repositories with Terraform.